### PR TITLE
Added support for NuGet feed discovery.

### DIFF
--- a/source/Glimpse.Site/Views/Shared/_Layout.cshtml
+++ b/source/Glimpse.Site/Views/Shared/_Layout.cshtml
@@ -11,6 +11,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <title>@ViewBag.Title</title>
     @Styles.Render("~/_Content/css")
+    <link rel="nuget" type="application/rsd+xml" href="http://www.myget.org/Discovery/Feed/glimpsenightly" />
 </head>
 <body class="layout">
     <header>


### PR DESCRIPTION
Added support for NuGet feed discovery. Check https://github.com/myget/FeedDiscovery for examples. In short, users can now: 

Install-Package DiscoverPackageSources 
Discover-PackageSources -Url "http://getglimpse.com" 

to add the nightlies feed to their NuGet package sources.
