### PR TITLE
GitHub contributors only requested on home page.

### DIFF
--- a/source/Glimpse.Site/Content/_v2/website-assets/scripts/home.js
+++ b/source/Glimpse.Site/Content/_v2/website-assets/scripts/home.js
@@ -94,7 +94,10 @@ function loadContributors() {
 $().ready(function () {
     //prep the page
 
-    loadContributors();
+    var theBody = $('body');
+    if (theBody.hasClass('home-page')) {
+        loadContributors();
+    }
     
     $('.hover-point').each(function() {
         //console.log($(this).attr('data-tipsy'));


### PR DESCRIPTION
loadContributors was being called on every page that includes home.js.

I've added a check to make sure we're on the home page before calling
loadContributors, so we shouldn't be making unnecessary requests to the
GitHub API.
