### PR TITLE
Fix lead developer's Twitter handle

### DIFF
--- a/source/Glimpse.Site/Content/committers.json
+++ b/source/Glimpse.Site/Content/committers.json
@@ -1,7 +1,7 @@
 ﻿[
 	{
 		"Name": "Anthony van der Hoorn",
-		"TwitterUsername": "avanderhoorn",
+		"TwitterUsername": "anthony_vdh",
 		"GithubUsername": "avanderhoorn",
 		"Category": "Reviewer",
 		"AvatarUrl": "https://avatars.githubusercontent.com/u/585619"


### PR DESCRIPTION
Change Anthony van der Hoorn's Twitter handle from avanderhoorn to anthony_vdh on the Community page
