### PR TITLE
Read key from environment

### DIFF
--- a/source/Glimpse.Site/App_Start/FilterConfig.cs
+++ b/source/Glimpse.Site/App_Start/FilterConfig.cs
@@ -1,5 +1,5 @@
-﻿using System.Web;
-using System.Web.Mvc;
+﻿using System.Web.Mvc;
+using Glimpse.Site.Telemetry;
 
 namespace Glimpse.Site
 {
@@ -7,7 +7,7 @@ namespace Glimpse.Site
     {
         public static void RegisterGlobalFilters(GlobalFilterCollection filters)
         {
-            filters.Add(new HandleErrorAttribute());
+            filters.Add(new ApplicationInsightsErrorAttribute());
         }
     }
 }

--- a/source/Glimpse.Site/ApplicationInsights.config
+++ b/source/Glimpse.Site/ApplicationInsights.config
@@ -15,7 +15,6 @@
   <TelemetryChannel Type="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.ServerTelemetryChannel, Microsoft.AI.ServerTelemetryChannel" />
   
   <TelemetryInitializers>
-    <Add Type="Microsoft.ApplicationInsights.WindowsServer.AzureRoleEnvironmentTelemetryInitializer, Microsoft.AI.WindowsServer" />
     <Add Type="Microsoft.ApplicationInsights.WindowsServer.DomainNameRoleInstanceTelemetryInitializer, Microsoft.AI.WindowsServer" />
     <Add Type="Microsoft.ApplicationInsights.WindowsServer.BuildInfoConfigComponentVersionTelemetryInitializer, Microsoft.AI.WindowsServer" />
     <Add Type="Microsoft.ApplicationInsights.WindowsServer.DeviceTelemetryInitializer, Microsoft.AI.WindowsServer" />

--- a/source/Glimpse.Site/Glimpse.Site.csproj
+++ b/source/Glimpse.Site/Glimpse.Site.csproj
@@ -20,6 +20,8 @@
     <IISExpressAnonymousAuthentication />
     <IISExpressWindowsAuthentication />
     <IISExpressUseClassicPipelineMode />
+    <GenerateBuildInfoConfigFile>true</GenerateBuildInfoConfigFile>
+    <IncludeServerNameInBuildInfo>true</IncludeServerNameInBuildInfo>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/source/Glimpse.Site/Glimpse.Site.csproj
+++ b/source/Glimpse.Site/Glimpse.Site.csproj
@@ -228,6 +228,7 @@
       <DesignTime>True</DesignTime>
       <DependentUpon>T4MVC.tt</DependentUpon>
     </Compile>
+    <Compile Include="Telemetry\ApplicationInsightsErrorAttribute.cs" />
     <Compile Include="Version.AdminController.generated.cs">
       <DependentUpon>T4MVC.tt</DependentUpon>
     </Compile>

--- a/source/Glimpse.Site/Global.asax.cs
+++ b/source/Glimpse.Site/Global.asax.cs
@@ -1,4 +1,5 @@
-﻿using System.Web.Http;
+﻿using System;
+using System.Web.Http;
 using System.Web.Mvc;
 using System.Web.Optimization;
 using System.Web.Routing;
@@ -8,6 +9,7 @@ using Glimpse.Contributor;
 using Glimpse.Package;
 using Glimpse.Release;
 using Glimpse.Twitter;
+using Microsoft.ApplicationInsights.Extensibility;
 
 namespace Glimpse.Site
 {
@@ -15,6 +17,14 @@ namespace Glimpse.Site
     {
         protected void Application_Start()
         { 
+            // Read instrumentation key from azure web app settings
+            string ikeyValue = Environment.GetEnvironmentVariable("APPINSIGHTS_INSTRUMENTATIONKEY");
+
+            if (!string.IsNullOrEmpty(ikeyValue))
+            {
+                TelemetryConfiguration.Active.InstrumentationKey = ikeyValue;
+            }
+
             AreaRegistration.RegisterAllAreas();
 
             GlobalConfiguration.Configure(WebApiConfig.Register);

--- a/source/Glimpse.Site/Telemetry/ApplicationInsightsErrorAttribute.cs
+++ b/source/Glimpse.Site/Telemetry/ApplicationInsightsErrorAttribute.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Web.Mvc;
+using Microsoft.ApplicationInsights;
+using Microsoft.ApplicationInsights.DataContracts;
+
+namespace Glimpse.Site.Telemetry
+{
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, Inherited = true, AllowMultiple = true)]
+    public class ApplicationInsightsErrorAttribute : HandleErrorAttribute
+    {
+        private TelemetryClient client = new TelemetryClient();
+
+        public override void OnException(ExceptionContext filterContext)
+        {
+            if (filterContext != null && filterContext.HttpContext != null && filterContext.Exception != null)
+            {
+                //If customError is Off, then AI HTTPModule will report the exception
+                if (filterContext.HttpContext.IsCustomErrorEnabled)
+                {
+                    ExceptionTelemetry exc = new ExceptionTelemetry(filterContext.Exception);
+                    exc.HandledAt = ExceptionHandledAt.Platform;
+                    client.TrackException(exc);
+                }
+                base.OnException(filterContext);
+            }
+        }
+    }
+}
+


### PR DESCRIPTION
This PR features more telemetry improvements:
- Track initialization exception
- Track exceptions from controllers processing
- Read instrumentation key from azure web app settings
- Remove unnecessary telemetry initializer
- Generate buildinfo.config file to track deployment versions